### PR TITLE
Replaced Patchwork/UTF8 by Symfony/String

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ---
 
-> Working with **Contao 4.9** and up to **Contao 4.12** (PHP ^7.4 and PHP 8)
+> Working with **Contao 4.9** and up to **Contao 4.13** (PHP ^7.4 and PHP 8)
 
 ---
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "php": "^7.4 || ^8.0",
         "ext-json":"*",
         "contao/core-bundle": "^4.9",
-        "symfony/http-foundation":"4.4.* || ^5.2"
+        "symfony/http-foundation":"4.4.* || ^5.2",
+        "symfony/string": "^5.4"
     },
     "conflict": {
         "contao/core": "*",

--- a/src/Resources/contao/classes/Glossary.php
+++ b/src/Resources/contao/classes/Glossary.php
@@ -25,6 +25,7 @@ use Contao\FrontendTemplate;
 use Contao\PageModel;
 use Contao\StringUtil;
 use Contao\System;
+use function Symfony\Component\String\u;
 
 /**
  * Provide methods regarding glossaries.
@@ -384,5 +385,13 @@ class Glossary extends Frontend
 
         // Link to the default page
         return sprintf(preg_replace('/%(?!s)/', '%%', $strUrl), ($objItem->alias ?: $objItem->id));
+    }
+
+    /**
+     * Returns a transliterated string
+     */
+    public static function transliterateAscii(string $string): string
+    {
+        return (string) u($string)->ascii();
     }
 }

--- a/src/Resources/contao/dca/tl_glossary_item.php
+++ b/src/Resources/contao/dca/tl_glossary_item.php
@@ -27,7 +27,6 @@ use Contao\Versions;
 use Oveleon\ContaoGlossaryBundle\Glossary;
 use Oveleon\ContaoGlossaryBundle\GlossaryItemModel;
 use Oveleon\ContaoGlossaryBundle\GlossaryModel;
-use Patchwork\Utf8;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 System::loadLanguageFile('tl_content');
@@ -531,7 +530,7 @@ class tl_glossary_item extends Backend
      */
     public function setGlossaryItemGroup(DataContainer $dc): void
     {
-        $newGroup = Utf8::strtoupper(mb_substr($dc->activeRecord->keyword, 0, 1, 'UTF-8'));
+        $newGroup = mb_strtoupper(mb_substr($dc->activeRecord->keyword, 0, 1, 'UTF-8'));
 
         if ($dc->activeRecord->letter !== $newGroup)
         {

--- a/src/Resources/contao/modules/ModuleGlossary.php
+++ b/src/Resources/contao/modules/ModuleGlossary.php
@@ -17,9 +17,9 @@ namespace Oveleon\ContaoGlossaryBundle;
 use Contao\FilesModel;
 use Contao\FrontendTemplate;
 use Contao\FrontendUser;
+use Contao\Module;
 use Contao\StringUtil;
 use Contao\System;
-use Patchwork\Utf8;
 
 /**
  * Parent class for glossary modules.
@@ -30,7 +30,7 @@ use Patchwork\Utf8;
  * @author Fabian Ekert <https://github.com/eki89>
  * @author Sebastian Zoglowek <https://github.com/zoglo>
  */
-abstract class ModuleGlossary extends \Module
+abstract class ModuleGlossary extends Module
 {
     /**
      * Sort out protected glossaries.
@@ -117,7 +117,7 @@ abstract class ModuleGlossary extends \Module
             foreach ($objAvailableGlossaryItems as $item)
             {
                 // Transliterate letters to valid Ascii
-                $itemGroup = $blnTransliteration ? Utf8::toAscii($item->letter) : $item->letter;
+                $itemGroup = $blnTransliteration ? Glossary::transliterateAscii($item->letter) : $item->letter;
 
                 $availableGroups[$itemGroup] = [
                     'item' => $this->generateGroupAnchorLink($itemGroup, $blnSingleGroup),
@@ -163,7 +163,7 @@ abstract class ModuleGlossary extends \Module
         foreach ($objGlossaryItems as $objGlossaryItem)
         {
             // Transliterate letters to valid Ascii
-            $itemGroup = $blnTransliteration ? Utf8::toAscii($objGlossaryItem->letter) : $objGlossaryItem->letter;
+            $itemGroup = $blnTransliteration ?  Glossary::transliterateAscii($objGlossaryItem->letter) : $objGlossaryItem->letter;
 
             $arrGlossaryGroups[$itemGroup]['id'] = 'group'.$this->id.'_'.$itemGroup;
             $arrGlossaryGroups[$itemGroup]['items'][] = $this->parseGlossaryItem($objGlossaryItem);

--- a/src/Resources/contao/modules/ModuleGlossaryList.php
+++ b/src/Resources/contao/modules/ModuleGlossaryList.php
@@ -19,7 +19,6 @@ use Contao\Config;
 use Contao\Input;
 use Contao\StringUtil;
 use Contao\System;
-use Patchwork\Utf8;
 
 /**
  * Front end module "glossary list".
@@ -56,7 +55,7 @@ class ModuleGlossaryList extends ModuleGlossary
         if ($request && System::getContainer()->get('contao.routing.scope_matcher')->isBackendRequest($request))
         {
             $objTemplate = new BackendTemplate('be_wildcard');
-            $objTemplate->wildcard = '### '.Utf8::strtoupper($GLOBALS['TL_LANG']['FMD']['glossary'][0]).' ###';
+            $objTemplate->wildcard = '### '. $GLOBALS['TL_LANG']['FMD']['glossary'][0] .' ###';
             $objTemplate->title = $this->headline;
             $objTemplate->id = $this->id;
             $objTemplate->link = $this->name;

--- a/src/Resources/contao/modules/ModuleGlossaryList.php
+++ b/src/Resources/contao/modules/ModuleGlossaryList.php
@@ -55,7 +55,7 @@ class ModuleGlossaryList extends ModuleGlossary
         if ($request && System::getContainer()->get('contao.routing.scope_matcher')->isBackendRequest($request))
         {
             $objTemplate = new BackendTemplate('be_wildcard');
-            $objTemplate->wildcard = '### '. $GLOBALS['TL_LANG']['FMD']['glossary'][0] .' ###';
+            $objTemplate->wildcard = '### '. mb_strtoupper($GLOBALS['TL_LANG']['FMD']['glossary'][0], 'UTF-8') .' ###';
             $objTemplate->title = $this->headline;
             $objTemplate->id = $this->id;
             $objTemplate->link = $this->name;

--- a/src/Resources/contao/modules/ModuleGlossaryReader.php
+++ b/src/Resources/contao/modules/ModuleGlossaryReader.php
@@ -23,7 +23,6 @@ use Contao\Input;
 use Contao\PageModel;
 use Contao\StringUtil;
 use Contao\System;
-use Patchwork\Utf8;
 
 /**
  * Front end module "glossary reader".
@@ -56,7 +55,7 @@ class ModuleGlossaryReader extends ModuleGlossary
         if ($request && System::getContainer()->get('contao.routing.scope_matcher')->isBackendRequest($request))
         {
             $objTemplate = new BackendTemplate('be_wildcard');
-            $objTemplate->wildcard = '### '.Utf8::strtoupper($GLOBALS['TL_LANG']['FMD']['glossaryreader'][0]).' ###';
+            $objTemplate->wildcard = '### '. $GLOBALS['TL_LANG']['FMD']['glossaryreader'][0] .' ###';
             $objTemplate->title = $this->headline;
             $objTemplate->id = $this->id;
             $objTemplate->link = $this->name;

--- a/src/Resources/contao/modules/ModuleGlossaryReader.php
+++ b/src/Resources/contao/modules/ModuleGlossaryReader.php
@@ -55,7 +55,7 @@ class ModuleGlossaryReader extends ModuleGlossary
         if ($request && System::getContainer()->get('contao.routing.scope_matcher')->isBackendRequest($request))
         {
             $objTemplate = new BackendTemplate('be_wildcard');
-            $objTemplate->wildcard = '### '. $GLOBALS['TL_LANG']['FMD']['glossaryreader'][0] .' ###';
+            $objTemplate->wildcard = '### '. mb_strtoupper($GLOBALS['TL_LANG']['FMD']['glossaryreader'][0], 'UTF-8') .' ###';
             $objTemplate->title = $this->headline;
             $objTemplate->id = $this->id;
             $objTemplate->link = $this->name;


### PR DESCRIPTION
<h3>Changes</h3>

- Replaced Patchwork/UTF8 by Symfony/String 61f384d2e05b0093f3e1d9064ace230e84c31325
- Removed Patchwork/UTF8 for backend modules b6fb1861f31cbc599fd0e6113310db5f2ab2dfcf
- Contao 4.13 Support c0b0e97f00f1fd7b71bb8f3ec1a28ee363425d5b