### PR TITLE
[Bugfix] Remove strict checks (in_array) to fix permissions for editi…

### DIFF
--- a/src/Resources/contao/dca/tl_content.php
+++ b/src/Resources/contao/dca/tl_content.php
@@ -67,10 +67,13 @@ class tl_content_glossary extends Backend
         {
             case '': // empty
             case 'paste':
-            case 'create':
             case 'select':
                 // Check access to the glossary item
                 $this->checkAccessToElement(CURRENT_ID, $root, true);
+                break;
+            case 'create':
+                // Check access to the parent element if a content element is created
+                $this->checkAccessToElement(Input::get('pid'), $root, 2 === (int) Input::get('mode'));
                 break;
 
             case 'editAll':
@@ -79,7 +82,7 @@ class tl_content_glossary extends Backend
             case 'cutAll':
             case 'copyAll':
                 // Check access to the parent element if a content element is moved
-                if (in_array(Input::get('act'), ['cutAll', 'copyAll'], true))
+                if (in_array(Input::get('act'), ['cutAll', 'copyAll']))
                 {
                     $this->checkAccessToElement(Input::get('pid'), $root, 2 === (int) Input::get('mode'));
                 }
@@ -142,7 +145,7 @@ class tl_content_glossary extends Backend
         }
 
         // The glossary is not mounted
-        if (!in_array($objArchive->id, $root, true))
+        if (!in_array($objArchive->id, $root))
         {
             throw new AccessDeniedException('Not enough permissions to modify article ID '.$objArchive->nid.' in glossary ID '.$objArchive->id.'.');
         }

--- a/src/Resources/contao/dca/tl_glossary.php
+++ b/src/Resources/contao/dca/tl_glossary.php
@@ -240,7 +240,7 @@ class tl_glossary extends Backend
             case 'copy':
             case 'delete':
             case 'show':
-                if (!in_array(Input::get('id'), $root, true) || ('delete' === Input::get('act') && !$this->User->hasAccess('delete', 'glossaryp')))
+                if (!in_array(Input::get('id'), $root) || ('delete' === Input::get('act') && !$this->User->hasAccess('delete', 'glossaryp')))
                 {
                     throw new AccessDeniedException('Not enough permissions to '.Input::get('act').' glossary ID '.Input::get('id').'.');
                 }
@@ -301,7 +301,7 @@ class tl_glossary extends Backend
         }
 
         // The glossary is enabled already
-        if (in_array($insertId, $root, true))
+        if (in_array($insertId, $root))
         {
             return;
         }
@@ -311,7 +311,7 @@ class tl_glossary extends Backend
 
         $arrNew = $objSessionBag->get('new_records');
 
-        if (is_array($arrNew['tl_glossary']) && in_array($insertId, $arrNew['tl_glossary'], true))
+        if (is_array($arrNew['tl_glossary']) && in_array($insertId, $arrNew['tl_glossary']))
         {
             // Add the permissions on group level
             if ('custom' !== $this->User->inherit)
@@ -322,7 +322,7 @@ class tl_glossary extends Backend
                 {
                     $arrGlossaryp = StringUtil::deserialize($objGroup->glossaryp);
 
-                    if (is_array($arrGlossaryp) && in_array('create', $arrGlossaryp, true))
+                    if (is_array($arrGlossaryp) && in_array('create', $arrGlossaryp))
                     {
                         $arrGlossarys = StringUtil::deserialize($objGroup->glossarys, true);
                         $arrGlossarys[] = $insertId;
@@ -344,7 +344,7 @@ class tl_glossary extends Backend
 
                 $arrGlossaryp = StringUtil::deserialize($objUser->glossaryp);
 
-                if (is_array($arrGlossaryp) && in_array('create', $arrGlossaryp, true))
+                if (is_array($arrGlossaryp) && in_array('create', $arrGlossaryp))
                 {
                     $arrGlossarys = StringUtil::deserialize($objUser->glossarys, true);
                     $arrGlossarys[] = $insertId;

--- a/src/Resources/contao/dca/tl_glossary_item.php
+++ b/src/Resources/contao/dca/tl_glossary_item.php
@@ -429,14 +429,14 @@ class tl_glossary_item extends Backend
             case 'paste':
             case 'select':
                 // Check CURRENT_ID here (see #247)
-                if (!in_array(CURRENT_ID, $root, true))
+                if (!in_array(CURRENT_ID, $root))
                 {
                     throw new AccessDeniedException('Not enough permissions to access glossary ID '.$id.'.');
                 }
                 break;
 
             case 'create':
-                if (!Input::get('pid') || !in_array(Input::get('pid'), $root, true))
+                if (!Input::get('pid') || !in_array(Input::get('pid'), $root))
                 {
                     throw new AccessDeniedException('Not enough permissions to create glossary items in glossary ID '.Input::get('pid').'.');
                 }
@@ -463,7 +463,7 @@ class tl_glossary_item extends Backend
                     $pid = Input::get('pid');
                 }
 
-                if (!in_array($pid, $root, true))
+                if (!in_array($pid, $root))
                 {
                     throw new AccessDeniedException('Not enough permissions to '.Input::get('act').' glossary item ID '.$id.' to glossary ID '.$pid.'.');
                 }
@@ -483,7 +483,7 @@ class tl_glossary_item extends Backend
                     throw new AccessDeniedException('Invalid glossary item ID '.$id.'.');
                 }
 
-                if (!in_array($objGlossary->pid, $root, true))
+                if (!in_array($objGlossary->pid, $root))
                 {
                     throw new AccessDeniedException('Not enough permissions to '.Input::get('act').' glossary item ID '.$id.' of glossary  ID '.$objGlossary->pid.'.');
                 }
@@ -494,7 +494,7 @@ class tl_glossary_item extends Backend
             case 'overrideAll':
             case 'cutAll':
             case 'copyAll':
-                if (!in_array($id, $root, true))
+                if (!in_array($id, $root))
                 {
                     throw new AccessDeniedException('Not enough permissions to access glossary ID '.$id.'.');
                 }
@@ -517,7 +517,7 @@ class tl_glossary_item extends Backend
                     throw new AccessDeniedException('Invalid command "'.Input::get('act').'".');
                 }
 
-                if (!in_array($id, $root, true))
+                if (!in_array($id, $root))
                 {
                     throw new AccessDeniedException('Not enough permissions to access glossary ID '.$id.'.');
                 }


### PR DESCRIPTION
<h3>Bugfix</h3>

- Remove strict checks (in_array) to fix permissions for editing glossaries and items (#21) https://github.com/oveleon/contao-glossary-bundle/commit/e9882529af777e5cad63b93f1a5c3e5c1a944949