### PR TITLE
Fix handling the auto_item in breadcrumb listener

### DIFF
--- a/src/EventListener/BreadcrumbListener.php
+++ b/src/EventListener/BreadcrumbListener.php
@@ -27,12 +27,14 @@ class BreadcrumbListener
 {
     public function __invoke(array $items): array
     {
+        $alias = Input::get('items');
+
         // Set the item from the auto_item parameter
         if (!isset($_GET['items']) && isset($_GET['auto_item']) && Config::get('useAutoItem')) {
-            Input::setGet('items', Input::get('auto_item'));
+            $alias = Input::get('auto_item');
         }
 
-        if (($alias = Input::get('items')) && ($glossaryItem = GlossaryItemModel::findPublishedByIdOrAlias($alias)) !== null) {
+        if ($alias && ($glossaryItem = GlossaryItemModel::findPublishedByIdOrAlias($alias)) !== null) {
             // Mark the last item as inactive
             $items[\count($items) - 1]['href'] = $GLOBALS['objPage']->getFrontendUrl();
             $items[\count($items) - 1]['isActive'] = false;


### PR DESCRIPTION
The problem is that BreadcrumbListener will attempt to set the `items` parameter from `auto_item`, which is a responsibility of the actual reader module (well, it shouldn't do that either) and has causes side effects. One of them being having the duplicated URL parameters, for example:

```
URL: domain.tld/en/event-reader/my-event-alias

[
    'items' => 'my-event-alias',
    'events' => 'my-event-alias',
]
```

That would conflict for example with the [changelanguage](https://github.com/terminal42/contao-changelanguage/blob/main/src/Navigation/UrlParameterBag.php#L126) extension.