### PR TITLE
Bugfix/page not routable

### DIFF
--- a/src/EventListener/BreadcrumbListener.php
+++ b/src/EventListener/BreadcrumbListener.php
@@ -27,14 +27,16 @@ class BreadcrumbListener
 {
     public function __invoke(array $items): array
     {
-        $alias = Input::get('items');
+        $alias = Input::get('items', 0, 1);
 
         // Set the item from the auto_item parameter
-        if (!isset($_GET['items']) && isset($_GET['auto_item']) && Config::get('useAutoItem')) {
-            $alias = Input::get('auto_item');
+        if (!isset($_GET['items']) && isset($_GET['auto_item']) && Config::get('useAutoItem'))
+        {
+            $alias = Input::get('auto_item', 0 , 1);
         }
 
-        if ($alias && ($glossaryItem = GlossaryItemModel::findPublishedByIdOrAlias($alias)) !== null) {
+        if ($alias && ($glossaryItem = GlossaryItemModel::findPublishedByIdOrAlias($alias)) !== null)
+        {
             // Mark the last item as inactive
             $items[\count($items) - 1]['href'] = $GLOBALS['objPage']->getFrontendUrl();
             $items[\count($items) - 1]['isActive'] = false;

--- a/src/EventListener/BreadcrumbListener.php
+++ b/src/EventListener/BreadcrumbListener.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace Oveleon\ContaoGlossaryBundle\EventListener;
 
 use Contao\Config;
+use Contao\CoreBundle\Exception\RouteParametersException;
 use Contao\Input;
 use Contao\StringUtil;
 use Oveleon\ContaoGlossaryBundle\Glossary;
@@ -32,25 +33,40 @@ class BreadcrumbListener
         // Set the item from the auto_item parameter
         if (!isset($_GET['items']) && isset($_GET['auto_item']) && Config::get('useAutoItem'))
         {
-            $alias = Input::get('auto_item', 0 , 1);
+            $alias = Input::get('auto_item', 0, 1);
         }
 
         if ($alias && ($glossaryItem = GlossaryItemModel::findPublishedByIdOrAlias($alias)) !== null)
         {
-            // Mark the last item as inactive
-            $items[\count($items) - 1]['href'] = $GLOBALS['objPage']->getFrontendUrl();
-            $items[\count($items) - 1]['isActive'] = false;
-
-            // Add the new item
-            $items[] = [
-                'isRoot' => false,
+            $breadcrumbItem = [
+                'isRoot'   => false,
                 'isActive' => true,
-                'href' => Glossary::generateUrl($glossaryItem),
-                'title' => StringUtil::specialchars($glossaryItem->keyword),
-                'link' => $glossaryItem->keyword,
-                'data' => $glossaryItem->row(),
-                'class' => '',
+                'href'     => Glossary::generateUrl($glossaryItem),
+                'title'    => StringUtil::specialchars($glossaryItem->keyword),
+                'link'     => $glossaryItem->keyword,
+                'data'     => $glossaryItem->row(),
+                'class'    => '',
             ];
+
+            try {
+                $href = $GLOBALS['objPage']->getFrontendUrl();
+            } catch (RouteParametersException $e) {
+                $href = '';
+            }
+
+            if (!strlen($href))
+            {
+                // In case the route alias already exists on the parent page, and it requires an item, simply replace the item
+                $items[\count($items) - 1] = $breadcrumbItem;
+            }
+            else
+            {
+                $items[\count($items) - 1]['href'] = $href;
+                $items[\count($items) - 1]['isActive'] = false;
+
+                // Append new item
+                $items[] = $breadcrumbItem;
+            }
         }
 
         return $items;


### PR DESCRIPTION
Fixes a few issues with the newly introduced breadcrumb listener

- auto item could not be found as none was given
- In case the route alias already exists on the parent page, and it requires an item, simply replace the item