### PR TITLE
Fix: Add cache invalidation for config json in page body

### DIFF
--- a/src/EventListener/GeneratePageListener.php
+++ b/src/EventListener/GeneratePageListener.php
@@ -145,6 +145,13 @@ class GeneratePageListener
 
         $objTemplate->glossaryConfig = $glossaryConfig;
 
+        // Tag glossary items
+        if (System::getContainer()->has('fos_http_cache.http.symfony_response_tagger'))
+        {
+            $responseTagger = System::getContainer()->get('fos_http_cache.http.symfony_response_tagger');
+            $responseTagger->addTags(array_map(static fn ($id) => 'contao.db.tl_glossary_item.'.$id, array_column($arrGlossaryItems, 'id')));
+        }
+
         $GLOBALS['TL_BODY'][] = $objTemplate->parse();
     }
 }


### PR DESCRIPTION
## How to reproduce the bug

- Create a glossary and, within it, an item with a keyword
- Enable glossary on page root
- Set a shared cache time (e. g. 5 minutes) in a page's settings
- (While not logged in) Call the page to cache the response. Inspect the page source and look at the config json.
- Change the item's keyword
- (While not logged in) Call the page again. Inspect the page source and look at the config json.

Result: The keyword has not changed. It only changes once the shared cache is invalidated by timeout.

## Fix

Tag the glossary entries in the `GeneratePageListener`.

## Note

The existing code in `GeneratePageListener` uses both dependency injection (for Contao Framework) and `System::getContainer()` (for `kernel.debug`), so I didn't know what you'd prefer.