### PR TITLE
Fix the glossary permissions

### DIFF
--- a/src/EventListener/DataContainer/ContentElementListener.php
+++ b/src/EventListener/DataContainer/ContentElementListener.php
@@ -47,13 +47,16 @@ class ContentElementListener
         }
 
         // Set the root IDs
-        if (empty($user->glossary) || !\is_array($user->glossary))
+        if (empty($user->glossarys) || !\is_array($user->glossarys))
         {
             $root = [0];
         }
         else
         {
-            $root = $user->glossary;
+            $root = $user->glossarys;
+            foreach ($root as $k => $v) {
+                $root[$k] = (int) $v;
+            }
         }
 
         // Check current action
@@ -113,14 +116,14 @@ class ContentElementListener
     {
         if ($isPid)
         {
-            $objArchive = $this->connection->fetchOne(
+            $objArchive = (object)$this->connection->fetchAssociative(
                 'SELECT a.id, n.id AS nid FROM tl_glossary_item n, tl_glossary a WHERE n.id=:id AND n.pid=a.id',
                 ['id' => $id],
             );
         }
         else
         {
-            $objArchive = $this->connection->fetchOne(
+            $objArchive = (object)$this->connection->fetchAssociative(
                 'SELECT a.id, n.id AS nid FROM tl_content c, tl_glossary_item n, tl_glossary a WHERE c.id=:id AND c.pid=n.id AND n.pid=a.id',
                 ['id' => $id],
             );

--- a/src/EventListener/DataContainer/ContentElementListener.php
+++ b/src/EventListener/DataContainer/ContentElementListener.php
@@ -54,7 +54,9 @@ class ContentElementListener
         else
         {
             $root = $user->glossarys;
-            foreach ($root as $k => $v) {
+
+            foreach ($root as $k => $v)
+            {
                 $root[$k] = (int) $v;
             }
         }
@@ -116,14 +118,14 @@ class ContentElementListener
     {
         if ($isPid)
         {
-            $objArchive = (object)$this->connection->fetchAssociative(
+            $objArchive = (object) $this->connection->fetchAssociative(
                 'SELECT a.id, n.id AS nid FROM tl_glossary_item n, tl_glossary a WHERE n.id=:id AND n.pid=a.id',
                 ['id' => $id],
             );
         }
         else
         {
-            $objArchive = (object)$this->connection->fetchAssociative(
+            $objArchive = (object) $this->connection->fetchAssociative(
                 'SELECT a.id, n.id AS nid FROM tl_content c, tl_glossary_item n, tl_glossary a WHERE c.id=:id AND c.pid=n.id AND n.pid=a.id',
                 ['id' => $id],
             );

--- a/src/EventListener/DataContainer/GlossaryItemListener.php
+++ b/src/EventListener/DataContainer/GlossaryItemListener.php
@@ -248,7 +248,9 @@ class GlossaryItemListener
         else
         {
             $root = $objUser->glossarys;
-            foreach ($root as $k => $v) {
+
+            foreach ($root as $k => $v)
+            {
                 $root[$k] = (int) $v;
             }
         }
@@ -269,7 +271,7 @@ class GlossaryItemListener
                 break;
 
             case 'create':
-                if (!Input::get('pid') || !\in_array((int)Input::get('pid'), $root, true))
+                if (!Input::get('pid') || !\in_array((int) Input::get('pid'), $root, true))
                 {
                     throw new AccessDeniedException('Not enough permissions to create glossary items in glossary ID '.Input::get('pid').'.');
                 }
@@ -296,7 +298,7 @@ class GlossaryItemListener
                     $pid = Input::get('pid');
                 }
 
-                if (!\in_array((int)$pid, $root, true))
+                if (!\in_array((int) $pid, $root, true))
                 {
                     throw new AccessDeniedException('Not enough permissions to '.Input::get('act').' glossary item ID '.$id.' to glossary ID '.$pid.'.');
                 }
@@ -327,7 +329,7 @@ class GlossaryItemListener
             case 'overrideAll':
             case 'cutAll':
             case 'copyAll':
-                if (!\in_array((int)$id, $root, true))
+                if (!\in_array((int) $id, $root, true))
                 {
                     throw new AccessDeniedException('Not enough permissions to access glossary ID '.$id.'.');
                 }
@@ -349,7 +351,7 @@ class GlossaryItemListener
                     throw new AccessDeniedException('Invalid command "'.Input::get('act').'".');
                 }
 
-                if (!\in_array((int)$id, $root, true))
+                if (!\in_array((int) $id, $root, true))
                 {
                     throw new AccessDeniedException('Not enough permissions to access glossary ID '.$id.'.');
                 }

--- a/src/EventListener/DataContainer/GlossaryItemListener.php
+++ b/src/EventListener/DataContainer/GlossaryItemListener.php
@@ -248,6 +248,9 @@ class GlossaryItemListener
         else
         {
             $root = $objUser->glossarys;
+            foreach ($root as $k => $v) {
+                $root[$k] = (int) $v;
+            }
         }
 
         $id = 0 !== \strlen(Input::get('id')) ? Input::get('id') : $dc->currentPid;
@@ -266,7 +269,7 @@ class GlossaryItemListener
                 break;
 
             case 'create':
-                if (!Input::get('pid') || !\in_array(Input::get('pid'), $root, true))
+                if (!Input::get('pid') || !\in_array((int)Input::get('pid'), $root, true))
                 {
                     throw new AccessDeniedException('Not enough permissions to create glossary items in glossary ID '.Input::get('pid').'.');
                 }
@@ -293,7 +296,7 @@ class GlossaryItemListener
                     $pid = Input::get('pid');
                 }
 
-                if (!\in_array($pid, $root, true))
+                if (!\in_array((int)$pid, $root, true))
                 {
                     throw new AccessDeniedException('Not enough permissions to '.Input::get('act').' glossary item ID '.$id.' to glossary ID '.$pid.'.');
                 }
@@ -324,7 +327,7 @@ class GlossaryItemListener
             case 'overrideAll':
             case 'cutAll':
             case 'copyAll':
-                if (!\in_array($id, $root, true))
+                if (!\in_array((int)$id, $root, true))
                 {
                     throw new AccessDeniedException('Not enough permissions to access glossary ID '.$id.'.');
                 }
@@ -346,7 +349,7 @@ class GlossaryItemListener
                     throw new AccessDeniedException('Invalid command "'.Input::get('act').'".');
                 }
 
-                if (!\in_array($id, $root, true))
+                if (!\in_array((int)$id, $root, true))
                 {
                     throw new AccessDeniedException('Not enough permissions to access glossary ID '.$id.'.');
                 }


### PR DESCRIPTION
Change user property from 'publications' to 'glossarys' in listeners for accurate access checks. Added type casting for glossary IDs and other entities to ensure consistency and prevent access issues.

Closes #51