### PR TITLE
Fix the permission check for the glossary picker

### DIFF
--- a/src/Picker/GlossaryPickerProvider.php
+++ b/src/Picker/GlossaryPickerProvider.php
@@ -55,7 +55,7 @@ class GlossaryPickerProvider extends AbstractInsertTagPickerProvider implements 
      */
     public function supportsContext($context): bool
     {
-        return 'link' === $context && $this->security->isGranted('contao_user.modules', 'glossarys');
+        return 'link' === $context && $this->security->isGranted('contao_user.modules', 'glossary');
     }
 
     public function supportsValue(PickerConfig $config): bool


### PR DESCRIPTION
see Issue #58 

Fix the missing Picker in the Contao Backend.